### PR TITLE
Feat/structure wrapper

### DIFF
--- a/src/core/helpers/wrapper.ts
+++ b/src/core/helpers/wrapper.ts
@@ -1,0 +1,139 @@
+
+/*!
+ * V4Fire Core
+ * https://github.com/V4Fire/Core
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Core/blob/master/LICENSE
+ */
+
+export type Instance = Array<unknown> |
+						WeakMap<object, unknown> |
+						WeakSet<object> |
+						Map<unknown, unknown> |
+						Set<unknown>;
+
+export interface CallbackStructureParams {
+	/**
+	 * Should provide additional parameters, such as which method called the callback
+	 */
+	info?: boolean;
+
+	/**
+	 * Don't call a callback to the list of specified methods
+	 */
+	ignore?: string[];
+
+	/**
+	 * If true, then a callback will be called using setImmediate
+	 */
+	deffer?: boolean;
+
+	/**
+	 * If true, then a proxy will be used to track changes
+	 *   *) callback will be called using setImmediate (if deffer is not set to false)
+	 *   *) ignore parameters will not be taken into account
+	 *   *) tracking through a proxy makes it possible to track changes in arrays through an index
+	 */
+	proxy?: boolean;
+}
+
+/**
+ * Creates a specified data structure which will call a specified callback on every mutation
+ *
+ * @param instance
+ * @param cb
+ * @param [params]
+ */
+export function wrapStructure<T extends Instance>(
+	instance: T,
+	cb: Function,
+	params: CallbackStructureParams = {}
+): T {
+	const {
+		ignore,
+		info
+	} = params;
+
+	let immediateId;
+
+	const shimTable = {
+		weakMap: [Object.isWeakMap, ['set', 'delete']],
+		weakSet: [Object.isWeakSet, ['add', 'delete']],
+		array: [Object.isArray, []],
+		map: [Object.isMap, ['set', 'delete', 'clear']],
+		set: [Object.isSet, ['add', 'delete', 'clear']]
+	};
+
+	const mapProxyHandler = {
+		get: (target, prop, receiver) => {
+			let res = Reflect.get(target, prop, receiver);
+
+			if (Object.isFunction(res)) {
+				res = res.bind(target);
+			}
+
+			return res;
+		}
+	}
+
+	const proxyHandler = {
+		array: (arr: Array<unknown>) => new Proxy(arr, {
+			get: (target, property) => target[property],
+			set: (target, property, value) => {
+				target[property] = value;
+
+				if (!immediateId) {
+					immediateId = setImmediate(() => {
+						cb('set', instance);
+						immediateId = undefined;
+					});
+				}
+
+				return true;
+			}
+		})
+	};
+
+	function caller<T>(ctx: unknown, method: Function, name: string, ...args: unknown[]): T {
+		const
+			a = info ? args.concat(name, instance) : [],
+			res = method.call(ctx, ...args);
+
+		cb(...a);
+		return res;
+	}
+
+	for (let i = 0, keys = Object.keys(shimTable); i < keys.length; i++) {
+		const
+			k = keys[i],
+			is = shimTable[k][0],
+			methods = shimTable[k][1];
+
+		if (!is(instance)) {
+			continue;
+		}
+
+		for (let j = 0; j < methods.length; j++) {
+			const
+				method = methods[j],
+				fn = instance[method];
+
+			if (ignore && ignore.includes(method)) {
+				continue;
+			}
+
+			instance[method] = function (...args: unknown[]): unknown {
+				return caller(this, fn, method, ...args);
+			};
+		}
+
+		if (wrapProxy[k]) {
+			instance = wrapProxy[k](instance);
+		}
+
+		break;
+	}
+
+	return instance;
+}

--- a/src/core/helpers/wrapper.ts
+++ b/src/core/helpers/wrapper.ts
@@ -119,7 +119,7 @@ export function wrapStructure<T extends Instance>(
 		object: {is: Object.isObject, proxy}
 	};
 
-	function caller<T>(ctx: unknown, method: Function, name: string, ...args: unknown[]): T {
+	function shim<T>(ctx: unknown, method: Function, name: string, ...args: unknown[]): T {
 		const
 			a = info ? args.concat(name, instance) : [],
 			res = method.call(ctx, ...args);
@@ -152,7 +152,7 @@ export function wrapStructure<T extends Instance>(
 			}
 
 			instance[method] = function (...args: unknown[]): unknown {
-				return caller(this, fn, method, ...args);
+				return shim(this, fn, method, ...args);
 			};
 		}
 

--- a/src/core/helpers/wrapper.ts
+++ b/src/core/helpers/wrapper.ts
@@ -1,4 +1,3 @@
-
 /*!
  * V4Fire Core
  * https://github.com/V4Fire/Core
@@ -8,11 +7,11 @@
  */
 
 export type Instance = Array<unknown> |
-						WeakMap<object, unknown> |
-						WeakSet<object> |
-						Map<unknown, unknown> |
-						Set<unknown> |
-						Dictionary;
+	WeakMap<object, unknown> |
+	WeakSet<object> |
+	Map<unknown, unknown> |
+	Set<unknown> |
+	Dictionary;
 
 export interface CallbackStructureParams {
 	/**

--- a/src/core/helpers/wrapper.ts
+++ b/src/core/helpers/wrapper.ts
@@ -51,7 +51,10 @@ export interface Params {
  * wrapStructure({}, () => console.log(123));
  * wrapStructure([1, 2], () => console.log(123));
  * wrapStructure(new Map(), () => console.log(123));
- * wrapStructure(new Set(), () => console.log(123));
+ *
+ * const s = wrapStructure(new Set(), () => console.log(123));
+ * s.add(1);
+ * // 123
  */
 export function wrapStructure<T extends Instance>(
 	instance: T,
@@ -101,11 +104,15 @@ export function wrapStructure<T extends Instance>(
 	});
 
 	const proxy = () => new Proxy(instance, {
-		get: (target, prop) => target[prop],
-		set: (target, prop, value) => {
-			target[prop] = value;
+		set: (...args) => {
+			const res = Reflect.set(...args);
 			wrappedCb('set', instance);
-			return true;
+			return res;
+		},
+		deleteProperty: (...args) => {
+			const res = Reflect.deleteProperty(...args);
+			wrappedCb('delete', instance);
+			return res;
 		}
 	});
 

--- a/src/core/helpers/wrapper.ts
+++ b/src/core/helpers/wrapper.ts
@@ -32,7 +32,6 @@ export interface CallbackStructureParams {
 
 	/**
 	 * If true, then a proxy will be used to track changes
-	 *   *) callback will be called using setImmediate (if deffer is not set to false)
 	 *   *) ignore parameters will not be taken into account
 	 *   *) tracking through a proxy makes it possible to track changes in arrays through an index
 	 */

--- a/src/core/helpers/wrapper.ts
+++ b/src/core/helpers/wrapper.ts
@@ -79,20 +79,20 @@ export function wrapStructure<T extends Instance>(
 		}
 	};
 
-	const structuresMutableMethods = {
+	const mutableMethodsSetMap = {
 		set: true,
 		add: true,
 		delete: true,
 		clear: true
 	};
 
-	const structureProxy = () => new Proxy(instance, {
+	const proxySetMap = () => new Proxy(instance, {
 		get: (target, prop, receiver) => {
 			const
 				val = Reflect.get(target, prop, receiver),
 				res = Object.isFunction(val) ? val.bind(target) : val;
 
-			if (structuresMutableMethods[prop]) {
+			if (mutableMethodsSetMap[prop]) {
 				wrappedCb('set', instance);
 			}
 
@@ -110,10 +110,10 @@ export function wrapStructure<T extends Instance>(
 	});
 
 	const shimTable = {
-		weakMap: {is: Object.isWeakMap, methods: ['set', 'delete'], proxy: structureProxy},
-		weakSet: {is: Object.isWeakSet, methods: ['add', 'delete'], proxy: structureProxy},
-		map: {is: Object.isMap, methods: ['set', 'delete', 'clear'], proxy: structureProxy},
-		set: {is: Object.isSet, methods: ['add', 'delete', 'clear'], proxy: structureProxy},
+		weakMap: {is: Object.isWeakMap, methods: ['set', 'delete'], proxy: proxySetMap},
+		weakSet: {is: Object.isWeakSet, methods: ['add', 'delete'], proxy: proxySetMap},
+		map: {is: Object.isMap, methods: ['set', 'delete', 'clear'], proxy: proxySetMap},
+		set: {is: Object.isSet, methods: ['add', 'delete', 'clear'], proxy: proxySetMap},
 		array: {is: Object.isArray, methods: ['push', 'pop', 'shift', 'unshift', 'sort', 'splice'], proxy},
 		object: {is: Object.isObject, proxy}
 	};

--- a/src/core/helpers/wrapper.ts
+++ b/src/core/helpers/wrapper.ts
@@ -13,7 +13,7 @@ export type Instance = Array<unknown> |
 	Set<unknown> |
 	Dictionary;
 
-export interface CallbackStructureParams {
+export interface Params {
 	/**
 	 * Should provide additional parameters, such as which method called the callback
 	 */
@@ -56,7 +56,7 @@ export interface CallbackStructureParams {
 export function wrapStructure<T extends Instance>(
 	instance: T,
 	cb: Function,
-	params: CallbackStructureParams = {}
+	params: Params = {}
 ): T {
 	const {
 		ignore,

--- a/src/core/helpers/wrapper.ts
+++ b/src/core/helpers/wrapper.ts
@@ -125,14 +125,14 @@ export function wrapStructure<T extends Instance>(
 		object: {is: Object.isObject, proxy}
 	};
 
-	function shim<T>(ctx: unknown, method: Function, name: string, ...args: unknown[]): T {
+	const shim = (ctx: unknown, method: Function, name: string, ...args: unknown[]) => {
 		const
 			a = info ? args.concat(name, instance) : [],
 			res = method.call(ctx, ...args);
 
 		wrappedCb(...a);
 		return res;
-	}
+	};
 
 	for (let i = 0, keys = Object.keys(shimTable); i < keys.length; i++) {
 		const


### PR DESCRIPTION
Враппер который на каждую мутацию переданного объекта вызывает переданный колбэк.

Может вызывать колбэк отложено (по умолчанию так и делает)
Умеет работать в 2 стратегии (шим методов или с использованием Proxy)
Умеет работать со всеми часто используемыми структурами данных
- Array
- WeakMap
- WeakSet
- Map
- Set
- Dictionary

2 стратегии потому что array.sort с использование proxy вызовется setter кучу раз, тут выручает setImmediate, но если выключить и setImmediate, то при вызове array.sort ты получишь много вызовов своего колбэка

Нужно ли закрыть runtime флагом?
И это было действительно сложным определится куда положить, так что здесь я не совсем уверен + с именем функции тоже не до конца уверен, возможно observe таки лучше?