### PR TITLE
fix/module: Return commonjs as default module

### DIFF
--- a/.tsconfig
+++ b/.tsconfig
@@ -5,6 +5,7 @@
     "downlevelIteration": true,
     "esModuleInterop": true,
     "importHelpers": true,
+    "module": "commonjs",
     "lib": ["dom", "esnext"],
     "allowJs": false,
     "skipLibCheck": true,


### PR DESCRIPTION
Для сборки в ESNext флаг module устанавливается в es6 и кажется из-за этого после сборки (fathmlt) получается не 1 а 3 файла, (android_android_ESNext.js и android_android_ESNext_4) например, и вот в главном файле он пытается подключить эти остальные и соответственно валится с ошибкой в приложении

![image](https://user-images.githubusercontent.com/5569667/63386239-3f47ba00-c3ab-11e9-8f89-0a3705bc58b8.png)

На самом деле я не совсем уверен, что это стоит именно так чинить, точнее точно нет, но это единственное что я сейчас успею, может у тебя есть какие-то идеи сходу? Если нет - то думаю можно вмержить, от этого ничего не меняется в принципе, потом докопаю почему


