### PR TITLE
Fix/async links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-beta.84 (2019-10-18)
+
+#### :bug: Bug Fix
+
+* [Fixed async links not being inherited](https://github.com/V4Fire/Core/pull/36)
+
 ## v3.0.0-beta.83 (2019-10-17)
 
 #### :rocket: New Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :bug: Bug Fix
 
-* [Fixed `Async.links` not inherited](https://github.com/V4Fire/Core/pull/36)
+* [Fixed `Async.links` override](https://github.com/V4Fire/Core/pull/36)
 
 ## v3.0.0-beta.83 (2019-10-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :bug: Bug Fix
 
-* [Fixed async links not being inherited](https://github.com/V4Fire/Core/pull/36)
+* [Fixed `Async.links` not inherited](https://github.com/V4Fire/Core/pull/36)
 
 ## v3.0.0-beta.83 (2019-10-17)
 

--- a/src/core/async.ts
+++ b/src/core/async.ts
@@ -258,7 +258,7 @@ export default class Async<CTX extends object = Async<any>> {
 	protected readonly context: CTX;
 
 	/**
-	 * Link for Async.linkNames
+	 * Link for this.linkNames
 	 */
 	protected get linkNames(): LinkNamesList {
 		return (<typeof Async>this.constructor).linkNames;
@@ -1727,7 +1727,7 @@ export default class Async<CTX extends object = Async<any>> {
 	 *   *) [group] - group name for the task
 	 */
 	clearAll(params?: ClearOpts): this {
-		for (let o = Async.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
+		for (let o = this.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
 			const
 				alias = `clear-${o[keys[i]]}`.camelize(false);
 
@@ -1750,7 +1750,7 @@ export default class Async<CTX extends object = Async<any>> {
 	 *   *) [group] - group name for the task
 	 */
 	muteAll(params?: ClearOpts): this {
-		for (let o = Async.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
+		for (let o = this.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
 			const
 				alias = `mute-${o[keys[i]]}`.camelize(false);
 
@@ -1770,7 +1770,7 @@ export default class Async<CTX extends object = Async<any>> {
 	 *   *) [group] - group name for the task
 	 */
 	unmuteAll(params?: ClearOpts): this {
-		for (let o = Async.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
+		for (let o = this.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
 			const
 				alias = `unmute-${o[keys[i]]}`.camelize(false);
 
@@ -1790,7 +1790,7 @@ export default class Async<CTX extends object = Async<any>> {
 	 *   *) [group] - group name for the task
 	 */
 	suspendAll(params?: ClearOpts): this {
-		for (let o = Async.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
+		for (let o = this.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
 			const
 				alias = `suspend-${o[keys[i]]}`.camelize(false);
 
@@ -1810,7 +1810,7 @@ export default class Async<CTX extends object = Async<any>> {
 	 *   *) [group] - group name for the task
 	 */
 	unsuspendAll(params?: ClearOpts): this {
-		for (let o = Async.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
+		for (let o = this.linkNames, keys = Object.keys(o), i = 0; i < keys.length; i++) {
 			const
 				alias = `unsuspend-${o[keys[i]]}`.camelize(false);
 

--- a/src/core/async.ts
+++ b/src/core/async.ts
@@ -258,7 +258,7 @@ export default class Async<CTX extends object = Async<any>> {
 	protected readonly context: CTX;
 
 	/**
-	 * Link for this.linkNames
+	 * Link for Async.linkNames
 	 */
 	protected get linkNames(): LinkNamesList {
 		return (<typeof Async>this.constructor).linkNames;


### PR DESCRIPTION
В общем, у Async в client не чистился animationFrame из-за того что Async.links указывал всегда на именно те links которые определены в этом конструкторе