### PR TITLE
Fix query template regexp

### DIFF
--- a/src/core/request/context.ts
+++ b/src/core/request/context.ts
@@ -27,7 +27,7 @@ import {
 
 const
 	resolveURLRgxp = /(?:^|(\w+:\/\/)(?:([^./]+)\.)?([^./]+)(?:\.([^./]+))?)(\/.*|$)/,
-	queryTplRgxp = /\:(.+?)(\(.*?\))?(?=[\\/.?#]|$)/g;
+	queryTplRgxp = /\:(.+?)(\(.*?\))?(?=[\\/\&.?#]|$)/g;
 
 export default class RequestContext<T = unknown> {
 	/**

--- a/src/core/request/context.ts
+++ b/src/core/request/context.ts
@@ -27,7 +27,7 @@ import {
 
 const
 	resolveURLRgxp = /(?:^|(\w+:\/\/)(?:([^./]+)\.)?([^./]+)(?:\.([^./]+))?)(\/.*|$)/,
-	queryTplRgxp = /\/:(.+?)(\(.*?\))?(?=[\\/.?#]|$)/g;
+	queryTplRgxp = /\:(.+?)(\(.*?\))?(?=[\\/.?#]|$)/g;
 
 export default class RequestContext<T = unknown> {
 	/**

--- a/src/core/request/utils.ts
+++ b/src/core/request/utils.ts
@@ -109,7 +109,7 @@ export function applyQueryForStr(str: string, query?: Dictionary, rgxp: RegExp =
 	}
 
 	return str.replace(rgxp, (str, param, adv = '') => {
-		if (query[param]) {
+		if (query[param] != null) {
 			const val = [query[param], delete query[param]][0];
 			return (str[0] === '/' ? '/' : '') + val + (Object.isNumber(adv) ? '' : adv);
 		}


### PR DESCRIPTION
В общем сейчас в POST запрос невозможно передать query параметры, чтобы это подлечить можно убрать из регулярки слэш и в baseURL интерполировать

Но в таком кейсе получается что всегда будут обязательные query параметры, поэтому возможно стоит лечить это более комплексно