### PR TITLE
Prevent unintentional growth of requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.9.1 ()
+
+#### :bug: Bug Fix
+* Fixed network connection status' checking algorithm
+
 ## v3.9.0 (2020-03-28)
 
 #### :rocket: New Feature

--- a/src/core/net/index.ts
+++ b/src/core/net/index.ts
@@ -23,8 +23,7 @@ const
 
 let
 	storage,
-	syncTimer,
-	retryCount = 0;
+	syncTimer;
 
 let
 	status,
@@ -62,7 +61,8 @@ export function isOnline(): Promise<NetStatus> {
 		}
 
 		let
-			loadFromStorage;
+			loadFromStorage,
+			retriesCount = 0;
 
 		if (online.persistence && !lastOnline) {
 			if (!storage) {
@@ -78,7 +78,7 @@ export function isOnline(): Promise<NetStatus> {
 
 		status = await new Promise<boolean>((resolve) => {
 			const retry = () => {
-				if (!online.retryCount || status === undefined || ++retryCount > online.retryCount) {
+				if (!online.retryCount || status === undefined || ++retriesCount > online.retryCount) {
 					resolve(false);
 
 				} else {
@@ -93,7 +93,6 @@ export function isOnline(): Promise<NetStatus> {
 
 				img.onload = () => {
 					clearTimeout(timer);
-					retryCount = 0;
 					resolve(true);
 				};
 


### PR DESCRIPTION
Пусть задан `retryCount = 3`. Тогда при очень медленном интернете, кроме основного, должно быть сделано ещё не больше 3 запросов за фавиконой для проверки интернета. Но на самом деле, число запросов будет постоянно увеличиваться.
**Причина**
1. Каждый запрос к фавиконке порождает ретрай через `checkTimeout`мс. При успешном запросе, этот ретрай должен заобортиться (`clearTimeout`), но при медленном интернете он успевает выполниться, пораждая тем самым новый запрос к фавиконке (со своим ретраем через `checkTimeout`мс). Таким образом, **при медленном интернете гарантировано будет вызван ретрай, который сделает новый запрос к фавиконке и, в свою очередь, гарантировано выполнит ретрай**.
2. `retryCount` должен ограничивать количество ретраев. Но счётчик текущего количества ретраев глобальный и обнуляется при каждом успешном запросе фавиконки. Это даёт возможность запускать новые ретраи, которые будут вызываться в образовавшемся "хвосте ретраев". Т.е., **при большом количестве медленных запросов к фавиконке успешное их выполнение будет давать возможность постоянно запускать новые ретраи из пункта 1**.
3. Изначальная функция проверки состояния сети, которая выполняет первый запрос к фавиконе, сама запускается с периодичностью `checkInterval` после резолва предыдущего запроса. Предыдущий запрос зарезолвится, если запрос фавиконки будет успешным либо если израсходуется лимит на ретраи. Значит постоянный запрос проверки сети сам будет пораждать всё новые "хвосты ретраев".

Поэтому в данном ПР текущий счётчик ретраев сделан локальным для запроса проверки состояния сети, гарантируя тем самым, что их число будет конечным.

Дополнительное тестирование показало следующие результаты:
fast internet
15rpm ~ постоянное число

slow internet(without fix)
1-ая мин.: **120req**,
2-ая мин.: **370req**,
3-ая мин.: **630req**,
4-ая мин.: **887req**
в общей сложности более **2000** запросов фав иконки за 4 мин

slow internet(with fix)
32rpm ~ постоянное число