### PR TITLE
Browser engine error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.17.4 (2020-05-29)
+
+#### :bug: Bug Fix
+
+* `browser` engine of `request` module now rejects with `RequestError` on `error` event
+
 ## v3.17.3 (2020-05-26)
 
 #### :house: Internal

--- a/src/core/request/engines/browser.ts
+++ b/src/core/request/engines/browser.ts
@@ -9,7 +9,7 @@
 import Then from 'core/then';
 import Response from 'core/request/response';
 import RequestError from 'core/request/error';
-import { RequestEngine } from 'core/request/interface';
+import { RequestEngine, RequestOptions } from 'core/request/interface';
 
 /**
  * Creates request by using XMLHttpRequest with the specified parameters and returns a promise
@@ -97,19 +97,13 @@ const request: RequestEngine = (params) => {
 		});
 
 		xhr.addEventListener('load', () => {
-			resolve(new Response(xhr.response, {
-				parent: p.parent,
-				important: p.important,
-				responseType: p.responseType,
-				okStatuses: p.okStatuses,
-				status: xhr.status,
-				headers: xhr.getAllResponseHeaders(),
-				decoder: p.decoders
-			}));
+			resolve(generateResponse(xhr, p));
 		});
 
 		xhr.addEventListener('error', (err) => {
-			reject(err);
+			reject(new RequestError('invalidStatus', {
+				response: generateResponse(xhr, p)
+			}));
 		});
 
 		xhr.addEventListener('timeout', () => {
@@ -119,5 +113,23 @@ const request: RequestEngine = (params) => {
 		xhr.send(data);
 	}, p.parent);
 };
+
+/**
+ * Generates response object based on passed arguments
+ *
+ * @param xhr
+ * @param opts
+ */
+function generateResponse(xhr: XMLHttpRequest, opts: RequestOptions): Response {
+	return new Response(xhr.response, {
+		parent: opts.parent,
+		important: opts.important,
+		responseType: opts.responseType,
+		okStatuses: opts.okStatuses,
+		status: xhr.status,
+		headers: xhr.getAllResponseHeaders(),
+		decoder: opts.decoders
+	});
+}
 
 export default request;


### PR DESCRIPTION
Добавил прокидывание исключения `RequestError` в движок `browser` на событие `error` в `xhr`. Нужно для мобилок. В десктопном браузере ошибки сети прилетают на событие `load` в `xhr`, но в вебвьюхе - на `error`