### PR TITLE
Fix incorrectly ignored errors in function `include`

### DIFF
--- a/build/include.js
+++ b/build/include.js
@@ -60,6 +60,16 @@ module.exports = function init(layers) {
 			return path.join(root, src);
 		}
 
+		function moduleExists(src) {
+			try {
+				require.resolve(src);
+				return true;
+
+			} catch {
+				return false;
+			}
+		}
+
 		let
 			resolvedLayers = layers;
 
@@ -90,16 +100,17 @@ module.exports = function init(layers) {
 
 			try {
 				if (opts.source) {
-					return fs.readFileSync(layerSrc).toString();
-				}
+					if (fs.existsSync(layerSrc)) {
+						return fs.readFileSync(layerSrc).toString();
+					}
 
-				return require(layerSrc);
+				} else if (moduleExists(layerSrc)) {
+					return require(layerSrc);
+				}
 
 			} catch (err) {
-				if (!{MODULE_NOT_FOUND: true, ENOENT: true}[err.code]) {
-					console.error(`Failed to load ${layerSrc}`);
-					throw err;
-				}
+				console.error(`Failed to load ${layerSrc}`);
+				throw err;
 			}
 		}
 


### PR DESCRIPTION
`require` throws exception `MODULE_NOT_FOUND` not only if required module doesn't exist, but also if successfully imported module in its turn requires non-existent modules.

Provided PR correctly handles this behaviour.