### PR TITLE
Обработка 204 статуса

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.x (2020-12-xx)
+
+#### :house: Internal
+
+* Added default mapping of content type `application/octet-stream` to response type `arrayBuffer`
+* Added response status checking whether it's 204 before decoding server response in `Response` class
+
 ## v3.29.0 (2020-12-22)
 
 #### :rocket: New Feature

--- a/src/core/mime-type/const.ts
+++ b/src/core/mime-type/const.ts
@@ -25,5 +25,6 @@ export const mimeTypes: Dictionary<DataType> = Object.createDict({
 	'application/x-www-form-urlencoded': 'text',
 	'application/x-msgpack': 'arrayBuffer',
 	'application/x-protobuf': 'arrayBuffer',
-	'application/vnd.google.protobuf': 'arrayBuffer'
+	'application/vnd.google.protobuf': 'arrayBuffer',
+	'application/octet-stream': 'arrayBuffer'
 });

--- a/src/core/request/CHANGELOG.md
+++ b/src/core/request/CHANGELOG.md
@@ -9,6 +9,13 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.x (2020-12-xx)
+
+#### :house: Internal
+
+* Added default mapping of content type `application/octet-stream` to response type `arrayBuffer`
+* Added response status checking whether it's 204 before decoding server response in `Response` class
+
 ## v3.28.0 (2020-11-06)
 
 #### :rocket: New Feature

--- a/src/core/request/response/index.ts
+++ b/src/core/request/response/index.ts
@@ -126,6 +126,7 @@ export default class Response<
 		this.responseType = contentType != null ? getDataType(contentType) : p.responseType;
 		this.sourceResponseType = this.responseType;
 
+		// tslint:disable-next-line:prefer-conditional-expression
 		if (p.decoder == null) {
 			this.decoders = [];
 
@@ -157,29 +158,35 @@ export default class Response<
 	@once
 	decode(): Then<D> {
 		let data;
-		switch (this.sourceResponseType) {
-			case 'json':
-				data = this.json();
-				break;
 
-			case 'arrayBuffer':
-				data = this.arrayBuffer();
-				break;
+		if (this.status === 204) {
+			data = Then.resolve(null, this.parent);
 
-			case 'blob':
-				data = this.blob();
-				break;
+		} else {
+			switch (this.sourceResponseType) {
+				case 'json':
+					data = this.json();
+					break;
 
-			case 'document':
-				data = this.document();
-				break;
+				case 'arrayBuffer':
+					data = this.arrayBuffer();
+					break;
 
-			case 'object':
-				data = Then.resolve(this.body, this.parent);
-				break;
+				case 'blob':
+					data = this.blob();
+					break;
 
-			default:
-				data = this.text();
+				case 'document':
+					data = this.document();
+					break;
+
+				case 'object':
+					data = Then.resolve(this.body, this.parent);
+					break;
+
+				default:
+					data = this.text();
+			}
 		}
 
 		let

--- a/src/core/request/spec.js
+++ b/src/core/request/spec.js
@@ -400,6 +400,11 @@ describe('core/request', () => {
 
 				expect(req.response.ok).toBeTrue();
 			});
+
+			it('response with 204 status', async () => {
+				const req = await request('http://localhost:3000/octet/204');
+				expect(req.data).toBe(null);
+			});
 		});
 	});
 });
@@ -471,6 +476,10 @@ function createServer() {
 
 		res.type('image/x-icon');
 		res.send(Buffer.from(faviconInBase64, 'base64'));
+	});
+
+	serverApp.get('/octet/204', (req, res) => {
+		res.type('application/octet-stream').status(204).end();
 	});
 
 	return serverApp.listen(3000);


### PR DESCRIPTION
Добавил обработку 204 статуса при декодинге ответа с сервера внутри объекта `Response`. Т.к. это может случиться при любом content-type, то проверка происходит перед всеми декодерами.

Дополнительно добавил дефолтный responseType `arrayBuffer` для content-type `application/octet-stream`