### PR TITLE
Пофиксить тест с Date.long

### DIFF
--- a/src/core/prelude/date/format/spec.js
+++ b/src/core/prelude/date/format/spec.js
@@ -27,11 +27,11 @@ describe('core/prelude/date/format', () => {
 	});
 
 	it('`long`', () => {
-		expect(date.long('en')).toBe('October 18, 1989, 10:10:10 AM');
+		expect(date.long('en')).toBe('October 18, 1989 at 10:10:10 AM');
 	});
 
 	it('`Date.long`', () => {
-		expect(Date.long('en')(date)).toBe('October 18, 1989, 10:10:10 AM');
+		expect(Date.long('en')(date)).toBe('October 18, 1989 at 10:10:10 AM');
 	});
 
 	it('`format`', () => {


### PR DESCRIPTION
Тест сломался потому что у node с версией 16.18 поменялоось форматирование дат сломав обратную совместимость