### PR TITLE
No unsafe JS

### DIFF
--- a/build/include.js
+++ b/build/include.js
@@ -28,23 +28,23 @@ const
 const IncludeOptions = {};
 
 /**
- * Returns a function to attach modules within node.js process with the support of WebPack "layers".
- * The returned function takes a path to require and takes a caller file's directory (to enable "@super" alias).
- * Also, the function can return a path or source code of the found file if there is provided special flag.
+ * Returns a function, which can import modules within node.js process from the specified directories.
+ * The returned function takes a path to require and optionally takes a caller file's directory (to enable "@super" alias).
+ * Also, the function can return a path or source code of the found file if a special flag is provided.
  *
  * @param {Array<string>} layers - list of layers
  * @returns {function (string, (string|IncludeOptions)?): ?}
  *
  * @example
  * ```js
- * global.include = include(['./', './node_modules/bla']);
+ * global.include = include(['./node_modules/bla', './']);
  *
- * // Searches the first existed file from a list:
+ * // Searches the first existing file from a list:
  * // ./build/i18n
  * // ./node_modules/bla/build/i18n
  * include('build/i18n');
  *
- * // Searches the first existed file from a list:
+ * // Searches the first existing file from a list:
  * // ./node_modules/bla/build/i18n
  * include('@super/build/i18n', __dirname);
  *
@@ -54,7 +54,7 @@ const IncludeOptions = {};
  * // Returns a path to the file
  * include('build/i18n', {return: 'path');
  *
- * // Returns source code of the file
+ * // Returns the source code of the file
  * include('@super/build/i18n', {return: 'source');
  * ```
  */

--- a/src/core/prelude/CHANGELOG.md
+++ b/src/core/prelude/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.??.?? (2023-??-??)
+
+#### :house: Internal
+
+* Updated global object definition to be universal for any JS environment `core/prelude/env/const`
+
 ## v3.??.?? (2022-??-??)
 
 #### :rocket: New Feature

--- a/src/core/prelude/env/const.ts
+++ b/src/core/prelude/env/const.ts
@@ -33,10 +33,11 @@ export const GLOBAL =
 	typeof window === 'object' && isGlobal(window) && window ||
 	typeof global === 'object' && isGlobal(global) && global ||
 	typeof self === 'object' && isGlobal(self) && self ||
-	(function getGlobalUnstrict() {
-		// eslint-disable-next-line @typescript-eslint/no-invalid-this
+
+	(function getGlobalUnstrict(this: unknown) {
 		return this;
 	}()) ||
+
 	// eslint-disable-next-line no-new-func
 	new Function('', 'return this')();
 
@@ -66,7 +67,7 @@ export const IS_NODE: boolean = (() => {
 
 /**
  * Checks if the provided value is a global object by confirming the presence of Math,
- * known to exist in any global JavaScript environment.
+ * known to exist in any global JS environment
  *
  * @param obj
  */

--- a/src/core/prelude/env/const.ts
+++ b/src/core/prelude/env/const.ts
@@ -6,6 +6,9 @@
  * https://github.com/V4Fire/Core/blob/master/LICENSE
  */
 
+/* eslint-disable no-restricted-globals */
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
 import { EventEmitter2 as EventEmitter } from 'eventemitter2';
 import { toString } from 'core/prelude/types/const';
 
@@ -25,9 +28,17 @@ export const
 /**
  * Link to the global object
  */
-export const
+export const GLOBAL =
+	typeof globalThis === 'object' && isGlobal(globalThis) && globalThis ||
+	typeof window === 'object' && isGlobal(window) && window ||
+	typeof global === 'object' && isGlobal(global) && global ||
+	typeof self === 'object' && isGlobal(self) && self ||
+	(function getGlobalUnstrict() {
+		// eslint-disable-next-line @typescript-eslint/no-invalid-this
+		return this;
+	}()) ||
 	// eslint-disable-next-line no-new-func
-	GLOBAL = Function('return this')();
+	new Function('', 'return this')();
 
 if (typeof globalThis === 'undefined') {
 	GLOBAL.globalThis = GLOBAL;
@@ -52,3 +63,13 @@ export const IS_NODE: boolean = (() => {
 		return false;
 	}
 })();
+
+/**
+ * Checks if the provided value is a global object by confirming the presence of Math,
+ * known to exist in any global JavaScript environment.
+ *
+ * @param obj
+ */
+function isGlobal(obj: any) {
+	return Boolean(obj) && obj.Math === Math;
+}


### PR DESCRIPTION
Использовать универсальное определение глобального объекта, чтобы с наименьшей вероятностью нарушать строгую CSP