### PR TITLE
Add workflow to release to npm on GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,28 @@ jobs:
 
       - run: yarn install
 
-      - run: yarn npm publish
+      - uses: actions/github-script@v7
+        name: Extract tag
+        id: extract-tag
+        with:
+          result-encoding: string
+          script: |
+            const { version } = require('${{ github.workspace }}/package.json');
+            const semver = require('semver');
+
+            const DEFAULT_TAG = 'latest';
+
+            const parsedVersion = semver.parse(version);
+            if (parsedVersion == null) {
+              return DEFAULT_TAG;
+            }
+            const { prerelease } = parsedVersion;
+            if (prerelease.length === 0) {
+              return DEFAULT_TAG;
+            }
+            const tag = prerelease[0];
+            return typeof tag === 'string' ? tag : DEFAULT_TAG;
+
+      - run: yarn npm publish --tag "${{ steps.extract-tag.outputs.result }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release to npm
+
+on:
+  release:
+    types: ["published"]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+          cache: "yarn"
+
+      - run: yarn install
+
+      - run: yarn npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The secret `NPM_TOKEN` needs to be added to the repo first by someone who has owner access.

**Question**: npm defaults the `tag` to `latest`, but I see on [`@v4fire/core` (npm)](https://www.npmjs.com/package/@v4fire/core?activeTab=versions) that we use both `alpha` and `beta` for `v4` releases. Should this be detected and set? And if so, based on what do we set `alpha` or `beta`?