### PR TITLE
chore(core/request/error): use WeakRef for error details only in node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-alpha.?? (2024-04-??)
+
+#### :house: Internal
+
+* Use `WeakRef` for `RequestError` details only in node environment `core/request/error`
+
 ## v4.0.0-alpha.30 (2024-04-09)
 
 #### :boom: Breaking Change

--- a/src/core/request/error/CHANGELOG.md
+++ b/src/core/request/error/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-alpha.?? (2024-04-??)
+
+#### :house: Internal
+
+* Use `WeakRef` for `RequestError` details only in node environment
+
 ## v3.86.4 (2022-07-05)
 
 #### :bug: Bug Fix

--- a/src/core/request/error/index.ts
+++ b/src/core/request/error/index.ts
@@ -11,6 +11,8 @@
  * @packageDocumentation
  */
 
+import { IS_NODE } from 'core/env';
+
 import BaseError from 'core/error';
 import type { Details } from 'core/request/error/interface';
 
@@ -65,7 +67,7 @@ export default class RequestError<D = undefined> extends BaseError {
 
 		this.type = type;
 
-		if (typeof WeakRef === 'function') {
+		if (typeof WeakRef === 'function' && IS_NODE) {
 			this.details = new WeakRef<Details<D>>(details);
 
 		} else {


### PR DESCRIPTION
Сейчас в любой момент информация из details может быть удалена, так как на нее нет сильных ссылок. 

Этот PR - просто заплатка, чтобы на клиенте ничего не сломалось, однако я полагаю, что проблема актуальна и для сервера: там также может не быть сильных ссылок на details, что приведет к ошибкам в компонентах, которые проверяют статус ответа.

Имеет смысл в WeakRef заворачивать только то, что реально течет.
