### PR TITLE
fixed unnecessary nesting when provider data is received from the cache

### DIFF
--- a/src/core/data/CHANGELOG.md
+++ b/src/core/data/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+#### :bug: Bug Fix
+
+* Fixed unnecessary nesting when data is received from the cache
+
 ## v3.83.0 (2022-04-05)
 
 #### :rocket: New Feature

--- a/src/core/data/modules/base.ts
+++ b/src/core/data/modules/base.ts
@@ -362,8 +362,12 @@ export default abstract class Provider extends ParamsProvider implements IProvid
 
 			const compositionRes = res.then(
 				(res) => Promise.all(tasks).then(async () => {
-					const
+					let
 						data = <Nullable<D & object>>(await res.data);
+
+					if (data && Object.hasOwnProperty(data, alias)) {
+						data = data[alias];
+					}
 
 					Object.set(composition, alias, data);
 					cloneTasks.push((composition) => Object.set(composition, alias, data?.valueOf()));


### PR DESCRIPTION
Был кейс с провайдером, у которого есть экстрапровайдер: 

Создается объект composition. В него записываются `composition['content']` (туда попадает `res.data`) и `composition['meta']`. Затем этот объект composition целиком записывается в `res.data`.

При следующем запросе берётся закэшированный `res`, который использовался в прошлый раз. Но в свойстве `res.data` уже лежит вложенная структура (`composition`). И уже она записывается в `composition['content']`.