### PR TITLE
Avoid set proxy blacklist into target object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-alpha.?? (2024-05-??)
+
+#### :bug: Bug Fix
+
+* Fixed an issue where a internal property `blackList` was being written to the target object `core/object/watch`
+
 ## v4.0.0-alpha.35 (2024-05-13)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :bug: Bug Fix
 
-* Fixed an issue where a internal property `blackList` was being written to the target object `core/object/watch`
+* Fixed an issue where an internal property, blackList, was being written to the target object `core/object/watch`
 
 ## v4.0.0-alpha.35 (2024-05-13)
 

--- a/src/core/object/watch/CHANGELOG.md
+++ b/src/core/object/watch/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog
 
 #### :bug: Bug Fix
 
-* Fixed an issue where a internal property `blackList` was being written to the target object
+* Fixed an issue where an internal property, blackList, was being written to the target object
 
 ## v3.87.1 (2022-08-15)
 

--- a/src/core/object/watch/CHANGELOG.md
+++ b/src/core/object/watch/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-alpha.?? (2024-05-??)
+
+#### :bug: Bug Fix
+
+* Fixed an issue where a internal property `blackList` was being written to the target object
+
 ## v3.87.1 (2022-08-15)
 
 #### :bug: Bug Fix

--- a/src/core/object/watch/engines/proxy.ts
+++ b/src/core/object/watch/engines/proxy.ts
@@ -46,7 +46,8 @@ import type {
 
 } from 'core/object/watch/interface';
 
-const globalProxyBlackList = new WeakMap<WatchHandlersSet, Set<string|symbol>>();
+const
+	globalProxyBlackList = new WeakMap<WatchHandlersSet, Set<string|symbol>>();
 
 /**
  * Watches for changes of the specified object by using Proxy objects

--- a/src/core/object/watch/engines/proxy.ts
+++ b/src/core/object/watch/engines/proxy.ts
@@ -9,7 +9,6 @@
 import {
 
 	muteLabel,
-	blackList,
 
 	toProxyObject,
 	toRootObject,
@@ -46,6 +45,8 @@ import type {
 	InternalWatchOptions
 
 } from 'core/object/watch/interface';
+
+const globalProxyBlackList = new WeakMap<WatchHandlersSet, Set<string|symbol>>();
 
 /**
  * Watches for changes of the specified object by using Proxy objects
@@ -188,7 +189,7 @@ export function watch<T extends object>(
 	});
 
 	const
-		blackListStore = new Set();
+		blackListStore = new Set<string|symbol>();
 
 	let
 		lastSetKey;
@@ -422,7 +423,7 @@ export function watch<T extends object>(
 		proxy = unwrappedObj;
 	}
 
-	getOrCreateLabelValueByHandlers(unwrappedObj, blackList, handlers, blackListStore);
+	globalProxyBlackList.set(handlers, blackListStore);
 	getOrCreateLabelValueByHandlers(unwrappedObj, toProxyObject, handlers, proxy);
 
 	return returnProxy(unwrappedObj, proxy);
@@ -463,7 +464,7 @@ export function set(obj: object, path: WatchPath, value: unknown, handlers: Watc
 	);
 
 	const
-		blackListStore = getOrCreateLabelValueByHandlers<Set<unknown>>(unwrappedObj, blackList, handlers),
+		blackListStore = globalProxyBlackList.get(handlers),
 		type = getProxyType(ref);
 
 	switch (type) {
@@ -518,7 +519,7 @@ export function unset(obj: object, path: WatchPath, handlers: WatchHandlersSet):
 	);
 
 	const
-		blackListStore = getOrCreateLabelValueByHandlers<Set<unknown>>(unwrappedObj, blackList, handlers),
+		blackListStore = globalProxyBlackList.get(handlers),
 		type = getProxyType(ref);
 
 	switch (type) {


### PR DESCRIPTION
Move blacklist to global WeakMap to avoid unnecessary mutating objects on get