### PR TITLE
fix(core/lazy): avoid reassigning `undefined` value for scheme from proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-alpha.?? (2024-09-??)
+
+#### :bug: Bug Fix
+
+* Avoid reassigning an `undefined` value for the scheme from the prototype `core/lazy`
+
 ## v4.0.0-alpha.43 (2024-07-29)
 
 #### :house: Internal

--- a/src/core/lazy/CHANGELOG.md
+++ b/src/core/lazy/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-alpha.?? (2024-09-??)
+
+#### :bug: Bug Fix
+
+* Avoid reassigning an `undefined` value for the scheme from the prototype
+
 ## v4.0.0-alpha.28 (2024-03-21)
 
 #### :bug: Bug Fix

--- a/src/core/lazy/index.ts
+++ b/src/core/lazy/index.ts
@@ -104,7 +104,11 @@ export function makeLazy<T extends ClassConstructor | AnyFunction>(
 				res[key] = Object.cast(Function);
 
 			} else {
-				res[key] = getSchemeFromProto(val);
+				const scheme = getSchemeFromProto(val);
+
+				if (scheme === undefined) {
+					res[key] = getSchemeFromProto(val)
+				}
 			}
 		});
 

--- a/src/core/lazy/index.ts
+++ b/src/core/lazy/index.ts
@@ -103,12 +103,8 @@ export function makeLazy<T extends ClassConstructor | AnyFunction>(
 			if (Object.isFunction(val)) {
 				res[key] = Object.cast(Function);
 
-			} else {
-				const scheme = getSchemeFromProto(val);
-
-				if (scheme === undefined) {
-					res[key] = getSchemeFromProto(val)
-				}
+			} else if (val !== undefined) {
+				res[key] = getSchemeFromProto(val);
 			}
 		});
 

--- a/src/core/lazy/spec.js
+++ b/src/core/lazy/spec.js
@@ -213,7 +213,7 @@ describe('core/lazy', () => {
 
 		Object.defineProperty(Object.prototype, 'test', {
 			set: () => {
-				throw ReferenceError(`Prototype key is reassigned: ${value}`);
+				throw ReferenceError('Prototype key is reassigned');
 			}
 		})
 

--- a/src/core/lazy/spec.js
+++ b/src/core/lazy/spec.js
@@ -212,6 +212,7 @@ describe('core/lazy', () => {
 		}
 
 		Object.defineProperty(Object.prototype, 'test', {
+			get: () => undefined,
 			set: () => {
 				throw ReferenceError('Prototype key is reassigned');
 			}
@@ -219,7 +220,7 @@ describe('core/lazy', () => {
 
 		expect(
 			makeLazy(createObj, {
-				a: 2,
+				a: 2
 			})
 		).not.toThrowError('ReferenceError: Prototype key is reassigned');
 	})

--- a/src/core/lazy/spec.js
+++ b/src/core/lazy/spec.js
@@ -205,4 +205,22 @@ describe('core/lazy', () => {
 		expect(engine1.component('newAwesomeComponent')).toBe(newAwesomeComponent);
 		expect(engine2.component('newAwesomeComponent')).toBe(newAwesomeComponent);
 	});
+
+	it('should not reassign a prototype key when it is `undefined`', () => {
+		function createObj(a) {
+			return {a};
+		}
+
+		Object.defineProperty(Object.prototype, 'test', {
+			set: () => {
+				throw ReferenceError(`Prototype key is reassigned: ${value}`);
+			}
+		})
+
+		expect(
+			makeLazy(createObj, {
+				a: 2,
+			})
+		).not.toThrowError('ReferenceError: Prototype key is reassigned');
+	})
 });

--- a/src/core/lazy/spec.js
+++ b/src/core/lazy/spec.js
@@ -216,12 +216,12 @@ describe('core/lazy', () => {
 			set: () => {
 				throw ReferenceError('Prototype key is reassigned');
 			}
-		})
+		});
 
 		expect(
 			makeLazy(createObj, {
 				a: 2
 			})
 		).not.toThrowError('ReferenceError: Prototype key is reassigned');
-	})
+	});
 });


### PR DESCRIPTION
closes #437