### PR TITLE
fix: empty string in arrayBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-alpha.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed an issue when receiving an empty string with the `Content-Type: application/octet-stream` header `core/request/response`
+
 ## v4.0.0-alpha.47.speedup (2024-10-01)
 
 #### :boom: Breaking Change

--- a/src/core/request/response/CHANGELOG.md
+++ b/src/core/request/response/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-alpha.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed an issue when receiving an empty string with the `Content-Type: application/octet-stream` header
+
 ## v3.93.0 (2023-03-14)
 
 #### :rocket: New Feature

--- a/src/core/request/response/index.ts
+++ b/src/core/request/response/index.ts
@@ -664,7 +664,7 @@ export default class Response<
 	@once
 	arrayBuffer(): AbortablePromise<ArrayBuffer> {
 		return this.readBody().then((body) => {
-			if (body == null ||  body === '') {
+			if (body == null || body === '') {
 				return new ArrayBuffer(0);
 			}
 

--- a/src/core/request/response/index.ts
+++ b/src/core/request/response/index.ts
@@ -664,7 +664,7 @@ export default class Response<
 	@once
 	arrayBuffer(): AbortablePromise<ArrayBuffer> {
 		return this.readBody().then((body) => {
-			if (body == null) {
+			if (body == null ||  body === '') {
 				return new ArrayBuffer(0);
 			}
 

--- a/src/core/request/response/test/main.spec.ts
+++ b/src/core/request/response/test/main.spec.ts
@@ -15,5 +15,5 @@ describe('core/request/response', () => {
 		});
 
 		await expect(response.decode()).resolves.toBeInstanceOf(ArrayBuffer);
-	})
-})
+	});
+});

--- a/src/core/request/response/test/main.spec.ts
+++ b/src/core/request/response/test/main.spec.ts
@@ -1,0 +1,19 @@
+import { Response } from 'core/request';
+import V4Headers from 'core/request/headers';
+
+describe('core/request/response', () => {
+	test([
+		'should successfully handle a request with the Content-Type: application/octet-stream header',
+		'and an empty response body'
+	].join(' '), async () => {
+
+		const response = new Response(Promise.resolve(''), {
+			url: 'url/url',
+			headers: new V4Headers({
+				'Content-Type': 'application/octet-stream'
+			})
+		});
+
+		await expect(response.decode()).resolves.toBeInstanceOf(ArrayBuffer);
+	})
+})


### PR DESCRIPTION
### Описание проблемы

Когда приходит заголовок `Content-Type: application/octet-stream`, может в ответе прийти пустая строка. Например, так происходит при некоторых условиях, в нодовой библиотеке http-outgoing, и в этом случае у нас падает ошибка `TypeError("Can't read response data as ArrayBuffer")`. Как я понимаю, пустая строка с таким заголовком является валидным